### PR TITLE
[Feat] Pager Indicator UI 수정

### DIFF
--- a/app/src/main/java/com/cmc/curtaincall/ui/OnBoardingScreen.kt
+++ b/app/src/main/java/com/cmc/curtaincall/ui/OnBoardingScreen.kt
@@ -18,12 +18,12 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.cmc.curtaincall.common.design.R
 import com.cmc.curtaincall.common.design.component.basic.CurtainCallRoundedTextButton
+import com.cmc.curtaincall.common.design.component.lib.pager.DynamicHorizontalPagerIndicator
 import com.cmc.curtaincall.common.design.extensions.toSp
 import com.cmc.curtaincall.common.design.theme.Cetacean_Blue
 import com.cmc.curtaincall.common.design.theme.Me_Pink
 import com.cmc.curtaincall.common.design.theme.White
 import com.cmc.curtaincall.common.design.theme.spoqahansanseeo
-import com.google.accompanist.pager.HorizontalPagerIndicator
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -50,14 +50,18 @@ internal fun OnBoardingScreen(
             .fillMaxSize()
             .background(Cetacean_Blue)
     ) {
-        HorizontalPagerIndicator(
+        DynamicHorizontalPagerIndicator(
             pagerState = pagerState,
             pageCount = pagerItems.size,
             modifier = Modifier
                 .align(Alignment.End)
                 .padding(top = 50.dp, end = 20.dp),
             activeColor = White,
-            inactiveColor = White.copy(0.2f)
+            activeIndicatorWidth = 16.dp,
+            activeIndicatorHeight = 7.dp,
+            inactiveColor = White.copy(0.2f),
+            inactiveIndicatorWidth = 7.dp,
+            spacing = 5.dp
         )
         HorizontalPager(
             state = pagerState

--- a/common/design/src/main/java/com/cmc/curtaincall/common/design/component/lib/pager/DynamicHorizontalPagerIndicator.kt
+++ b/common/design/src/main/java/com/cmc/curtaincall/common/design/component/lib/pager/DynamicHorizontalPagerIndicator.kt
@@ -1,0 +1,58 @@
+package com.cmc.curtaincall.common.design.component.lib.pager
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun DynamicHorizontalPagerIndicator(
+    pagerState: PagerState,
+    pageCount: Int,
+    modifier: Modifier = Modifier,
+    pageIndexMapping: (Int) -> Int = { it },
+    activeColor: Color = Color.Unspecified,
+    activeIndicatorWidth: Dp = 8.dp,
+    activeIndicatorHeight: Dp = activeIndicatorWidth,
+    inactiveColor: Color = Color.Unspecified,
+    inactiveIndicatorWidth: Dp = 8.dp,
+    inactiveIndicatorHeight: Dp = inactiveIndicatorWidth,
+    spacing: Dp = 8.dp,
+    indicatorShape: Shape = CircleShape,
+) {
+    Box(
+        modifier = modifier,
+        contentAlignment = Alignment.CenterStart
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(spacing),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            val position = pageIndexMapping(pagerState.currentPage)
+            (0 until pageCount).forEach { index ->
+                val indicatorModifier = Modifier
+                    .size(
+                        width = if (index == position) activeIndicatorWidth else inactiveIndicatorWidth,
+                        height = if (index == position) activeIndicatorHeight else inactiveIndicatorHeight
+                    )
+                    .background(
+                        color = if (index == position) activeColor else inactiveColor,
+                        shape = indicatorShape
+                    )
+                Box(indicatorModifier)
+            }
+        }
+    }
+}

--- a/feature/home/src/main/java/com/cmc/curtaincall/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/cmc/curtaincall/feature/home/HomeScreen.kt
@@ -26,13 +26,13 @@ import com.cmc.curtaincall.common.design.component.content.card.LiveTalkContentC
 import com.cmc.curtaincall.common.design.component.content.card.MyContentCard
 import com.cmc.curtaincall.common.design.component.content.card.PerformanceCard
 import com.cmc.curtaincall.common.design.component.content.row.ContentTitleRow
+import com.cmc.curtaincall.common.design.component.lib.pager.DynamicHorizontalPagerIndicator
 import com.cmc.curtaincall.common.design.extensions.toSp
 import com.cmc.curtaincall.common.design.theme.*
 import com.cmc.curtaincall.common.utility.extensions.toDateWithDay
 import com.cmc.curtaincall.common.utility.extensions.toDday
 import com.cmc.curtaincall.common.utility.extensions.toTime
 import com.cmc.curtaincall.feature.home.guide.GuideType
-import com.google.accompanist.pager.HorizontalPagerIndicator
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import io.getstream.chat.android.client.ChatClient
 
@@ -449,17 +449,18 @@ internal fun HomeBanner(
                 onClick = bannerItems[position].onClick
             )
         }
-        HorizontalPagerIndicator(
+        DynamicHorizontalPagerIndicator(
             pagerState = pagerState,
             pageCount = bannerItems.size,
             modifier = Modifier
                 .align(Alignment.CenterHorizontally)
                 .padding(top = 14.dp),
             activeColor = White,
-            inactiveColor = White.copy(alpha = 0.2f),
-            indicatorWidth = 7.dp,
-            indicatorHeight = 7.dp,
-            spacing = 5.dp
+            activeIndicatorWidth = 14.dp,
+            activeIndicatorHeight = 6.dp,
+            inactiveColor = White.copy(0.2f),
+            inactiveIndicatorWidth = 6.dp,
+            spacing = 6.dp
         )
     }
 }


### PR DESCRIPTION
## What task did you do?
Pager Indicator 포커스 시에 가로가 긴 원 형태로 변경되도록 UI 수정

### What subtasks did you do?
- [x] DynamicHorizontalPagerIndicator 컴포저블 생성
- [x] HomeScreen, OnBoardingScreen에 컴포넌트 적용

### ScreenShot (optional)
<img src="https://github.com/CurtainCall-App/CurtainCall-AOS/assets/34837583/2a2db6ae-afae-4928-a6f3-b115da81b861" width=300 height=670/> <img src="https://github.com/CurtainCall-App/CurtainCall-AOS/assets/34837583/79566526-2d3e-40a9-b9a1-4a6b20bad044" width=300 height=670/>

### Close Issue
Close #166 
